### PR TITLE
Add robust LoRA generation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # git-lora
+
+This repository demonstrates how to generate text with transformer models
+patched by [LoRA](https://arxiv.org/abs/2106.09685) adapters.
+
+## Example
+
+The trivial `generate_trivial_v0()` sample has been replaced by the more
+capable `generate_with_lora()` function.  It shows how to load a base model,
+apply LoRA weights, and control generation parameters such as temperature,
+maximum token count, and randomness seed.
+
+```python
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from peft import PeftModel
+
+from example import generate_with_lora
+
+# Path to your LoRA adapter weights
+ADAPTER = "./my_lora_adapter"
+
+text = generate_with_lora(
+    "Once upon a time",
+    ADAPTER,
+    max_new_tokens=50,
+    temperature=0.8,
+    seed=1234,
+)
+print(text)
+```

--- a/example.py
+++ b/example.py
@@ -1,0 +1,59 @@
+"""Example of generating text with a model patched by LoRA weights.
+
+This example replaces the old `generate_trivial_v0` snippet with a more
+full-featured `generate_with_lora` function.  It demonstrates how to load
+base and LoRA adapters, control generation parameters such as
+`temperature`, `max_new_tokens`, and make generation deterministic with a
+seed.
+"""
+
+from typing import Optional
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import PeftModel
+
+
+def generate_with_lora(
+    prompt: str,
+    lora_weights: str,
+    *,
+    max_new_tokens: int = 64,
+    temperature: float = 0.7,
+    seed: Optional[int] = None,
+) -> str:
+    """Generate text using a transformer model with LoRA weights applied.
+
+    Args:
+        prompt: The text to start generation from.
+        lora_weights: Path or identifier of the LoRA adapter weights.
+        max_new_tokens: Number of new tokens to generate.
+        temperature: Sampling temperature used during generation.
+        seed: Optional random seed for deterministic sampling.
+
+    Returns:
+        The generated text with special tokens stripped.
+    """
+
+    if seed is not None:
+        import torch
+        torch.manual_seed(seed)
+
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    base_model = AutoModelForCausalLM.from_pretrained("gpt2")
+    model = PeftModel.from_pretrained(base_model, lora_weights)
+
+    inputs = tokenizer(prompt, return_tensors="pt")
+    output_ids = model.generate(
+        **inputs,
+        max_new_tokens=max_new_tokens,
+        temperature=temperature,
+        do_sample=True,
+        pad_token_id=tokenizer.eos_token_id,
+    )
+    return tokenizer.decode(output_ids[0], skip_special_tokens=True)
+
+
+if __name__ == "__main__":
+    # Example usage
+    text = generate_with_lora("Once upon a time", "./my_lora_adapter", max_new_tokens=20)
+    print(text)


### PR DESCRIPTION
## Summary
- replace trivial generate_trivial_v0 sample with generate_with_lora demonstrating adapter loading and generation controls
- document new example in README

## Testing
- `python -m py_compile example.py`


------
https://chatgpt.com/codex/tasks/task_e_689612e04ed88331b41d452683c3d0ed